### PR TITLE
Fix improper dates for event submit

### DIFF
--- a/utmap-client/src/components/pages/CreateEventPage.js
+++ b/utmap-client/src/components/pages/CreateEventPage.js
@@ -66,13 +66,18 @@ function CreateEventPage({onClose, addEvent}) {
 		//Send info???
 		startDate.setSeconds(0,0);
 		endDate.setSeconds(0,0);
-		const eventForm = {
-			title, 
-			startDate: startDate.toLocaleString('en-US', { timeZone: 'America/New_York' }), 
-			endDate: endDate.toLocaleString('en-US', { timeZone: 'America/New_York' }),
-			location, sublocation, description};
-		addEvent(eventForm);
-		onClose();
+		
+		if (startDate > endDate){
+			alert("End date must be after start date")
+		} else {
+			const eventForm = {
+				title, 
+				startDate: startDate.toLocaleString('en-US', { timeZone: 'America/New_York' }), 
+				endDate: endDate.toLocaleString('en-US', { timeZone: 'America/New_York' }),
+				location, sublocation, description};
+			addEvent(eventForm);
+			onClose();
+		}
 	}
 
 


### PR DESCRIPTION
- Prevent form from submitting when user clicks Submit, if start date is after end date
- Throw an alert when this happens

![image](https://user-images.githubusercontent.com/25747480/107909860-27f97680-6f27-11eb-9ad9-3fc662942497.png)

