### PR TITLE
Prevent user from closing event form clicking outside box

### DIFF
--- a/utmap-client/src/components/pages/CalendarPage.js
+++ b/utmap-client/src/components/pages/CalendarPage.js
@@ -136,7 +136,11 @@ function CalendarPage() {
 			</Button>
 			
 			{/* Popup box for event form */}
-			<Dialog open={openEventForm} onClose={handleOpenEventForm}>
+			<Dialog 
+				open={openEventForm} 
+				onClose={handleOpenEventForm}
+				disableBackdropClick
+      	disableEscapeKeyDown>
 				<CreateEventPage onClose={handleOpenEventForm} addEvent={addEvent}/>
 			</Dialog>
 


### PR DESCRIPTION
- Did not create a dialog popup box
- User can click outside the form and the form will not close
- User can still close the form and lose all progress by clicking the "X" button

![image](https://user-images.githubusercontent.com/13726465/108442290-cab23d80-7224-11eb-852b-6685483acd19.png)
