### PR TITLE
Create environment variables with safe defaults.

### DIFF
--- a/utmap-server/src/app/main/config.py
+++ b/utmap-server/src/app/main/config.py
@@ -9,22 +9,27 @@ class Config:
 
 class DevelopmentConfig(Config):
     DEBUG = True
-    MONGODB_HOST = 'localhost'
-    MONGODB_PORT = 27017
+    MONGODB_HOST = os.getenv('MONGODB_HOST', 'localhost')
+    MONGODB_PORT = os.getenv('MONGODB_PORT', 27017)
+    SERVER_PORT = os.getenv('SERVER_PORT', 5000)
     MONGODB_TRACK_MODIFICATIONS = False
 
 
 class TestingConfig(Config):
     DEBUG = True
     TESTING = True
-    MONGODB_HOST = 'localhost'
-    MONGODB_PORT = 27017
+    MONGODB_HOST = os.getenv('MONGODB_HOST', 'localhost')
+    MONGODB_PORT = os.getenv('MONGODB_PORT', 27017)
+    SERVER_PORT = os.getenv('SERVER_PORT', 5001)
     PRESERVE_CONTEXT_ON_EXCEPTION = False
     MONGODB_TRACK_MODIFICATIONS = False
 
 
 class ProductionConfig(Config):
     DEBUG = False
+    MONGODB_HOST = os.getenv('MONGODB_HOST', 'localhost')
+    MONGODB_PORT = os.getenv('MONGODB_PORT', 27017)
+    SERVER_PORT = os.getenv('SERVER_PORT', 5002)
 
 
 configByName = dict(


### PR DESCRIPTION
- In config.py, turn MONGODB_HOST and MONGODB_PORT into environment variables with safe defaults.
- Add environment variable SERVER_PORT with safe defaults to all Config objects in config.py