### PR TITLE
Issue 43 calendar max events per day indicator

### DIFF
--- a/utmap-client/src/components/SideBarContent.js
+++ b/utmap-client/src/components/SideBarContent.js
@@ -8,24 +8,19 @@ import EventList from './EventList';
 import NavigationBar from './NavigationBar';
 
 
-function SideBarContent({events}) {
-	const sortedEvents = events.sort((a, b) => {
-		//sort by startDate, earliest to latest
-		return (Date.parse(a.startDate) < Date.parse(b.startDate)) ? -1 : 1; 
-	});
-	
-	const [eventList, setEventList] = useState(sortedEvents);
+function SideBarContent({events}) {	
+	const [eventList, setEventList] = useState(events);
 
 	const filterEvents = useCallback((searchTerm) => {
-		const filteredEvents = sortedEvents.filter(event =>
+		const filteredEvents = events.filter(event =>
 			event.title.toLowerCase().includes(searchTerm)
 		);
 		setEventList(filteredEvents);
-	},[sortedEvents]);
+	},[events]);
 
 	useEffect(() => {
-		setEventList(sortedEvents);
-	}, [sortedEvents]);
+		setEventList(events);
+	}, [events]);
 
 	return (
 		<List>


### PR DESCRIPTION
- Moved event sorting function from SidebarContent to CalendarPage (events are now sorted before passing into sidebar)
- Sidebar and Calendar now have a separate list of events each
- Calendar will group events together if there are more than 3 in a day
- Calendar will display grouped events as "`num`+ events"
- Click on a grouped event on the calendar and it will display a popup view of an EventList
![](https://cdn.discordapp.com/attachments/798579502543536218/815035408273899520/unknown.png)  
![](https://cdn.discordapp.com/attachments/798579502543536218/815458969920208956/unknown.png)