### PR TITLE
Increase visibility of expand description icon

### DIFF
--- a/utmap-client/src/components/pages/SingleEventPage.js
+++ b/utmap-client/src/components/pages/SingleEventPage.js
@@ -120,14 +120,17 @@ function SingleEventPage({event, closePopup, handleEdit}) {
 					</Grid>
 
 					{/* Description */}
-					<div align="right">
-						<IconButton onClick={handleExpandClick} aria-label="show more">
-							{expanded ? <ExpandLessIcon/> : <ExpandMoreIcon/>}
+					<div align="center">
+						<IconButton onClick={handleExpandClick} disableRipple aria-label="show more">
+							<Typography variant="caption">
+								DESCRIPTION
+							</Typography>
+							{expanded ? <ExpandLessIcon fontSize={'large'}/> : <ExpandMoreIcon fontSize={'large'}/>}
 						</IconButton>
 					</div>
 					<Collapse in={expanded} timeout="auto" unmountOnExit>
 						<Typography variant="body2" component="span">
-							Description: {description}
+							{description}
 						</Typography>
 					</Collapse>
 


### PR DESCRIPTION
- Center and increase the size of the expansion button
- Add "description" next to button
![image](https://user-images.githubusercontent.com/25747480/111085037-e3dca000-84eb-11eb-95ad-d039f9fea0bf.png)
