### PR TITLE
Create default buildings and send to db on start

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,6 +12,7 @@ services:
       - SERVER_HOST=0.0.0.0
       - SERVER_PORT=5002
       - DEBUG=False
+      - BUILDINGS=building_config.json
     ports:
       - 8082:5002
   

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,6 +9,7 @@ services:
       - UTMAP_ENV=prod
       - MONGODB_HOST=mongo
       - MONGODB_PORT=27017
+      - SKIP_DB_INIT=True
       - SERVER_HOST=0.0.0.0
       - SERVER_PORT=5002
       - DEBUG=False

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,7 +9,7 @@ services:
       - UTMAP_ENV=prod
       - MONGODB_HOST=mongo
       - MONGODB_PORT=27017
-      - SKIP_DB_INIT=True
+      - SKIP_DB_INIT=False
       - SERVER_HOST=0.0.0.0
       - SERVER_PORT=5002
       - DEBUG=False

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -12,6 +12,7 @@ services:
       - SERVER_HOST=0.0.0.0
       - SERVER_PORT=5001
       - DEBUG=True
+      - BUILDINGS=building_config.json
     ports:
       - 8081:5001
   

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,6 +9,7 @@ services:
       - UTMAP_ENV=test
       - MONGODB_HOST=mongo
       - MONGODB_PORT=27017
+      - SKIP_DB_INIT=False
       - SERVER_HOST=0.0.0.0
       - SERVER_PORT=5001
       - DEBUG=True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - SERVER_HOST=0.0.0.0
       - SERVER_PORT=5000
       - DEBUG=True
+      - BUILDINGS=building_config.json
     ports:
       - 8080:5000
   

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - UTMAP_ENV=dev
       - MONGODB_HOST=mongo
       - MONGODB_PORT=27017
+      - SKIP_DB_INIT=False
       - SERVER_HOST=0.0.0.0
       - SERVER_PORT=5000
       - DEBUG=True

--- a/utmap-server/src/app/main/__init__.py
+++ b/utmap-server/src/app/main/__init__.py
@@ -1,6 +1,6 @@
 from flask import Flask
 from pymongo import MongoClient
-from .config import configByName, dbHost, dbPort, dbName, serverHost, serverPort, debugSetting
+from .config import configByName, dbHost, dbPort, dbName, serverHost, serverPort, debugSetting, skipDBInit
 
 db = MongoClient(dbHost, dbPort).get_database(dbName)
 

--- a/utmap-server/src/app/main/config.py
+++ b/utmap-server/src/app/main/config.py
@@ -6,10 +6,10 @@ class Config:
     SECRET_KEY = os.getenv('SECRET KEY', 'skeleton_key_sans_undertale_haha')
     MONGODB_HOST = os.getenv('MONGODB_HOST', 'localhost')
     MONGODB_PORT = int(os.getenv('MONGODB_PORT', 27017))
-    SKIP_DB_INIT = os.getenv('SKIP_DB_INIT', False)
+    SKIP_DB_INIT = os.getenv('SKIP_DB_INIT', 'False') == 'True'
     SERVER_HOST = os.getenv('SERVER_HOST', '127.0.0.0')
     SERVER_PORT = int(os.getenv('SERVER_PORT', 5000))
-    DEBUG = bool(os.getenv('SERVER_PORT', False))
+    DEBUG = os.getenv('DEBUG', 'False') == 'True'
     BUILDINGS = os.getenv('BUILDINGS', 'building_config.json')
 
 

--- a/utmap-server/src/app/main/config.py
+++ b/utmap-server/src/app/main/config.py
@@ -9,6 +9,7 @@ class Config:
     SERVER_HOST = os.getenv('SERVER_HOST', '127.0.0.0')
     SERVER_PORT = int(os.getenv('SERVER_PORT', 5000))
     DEBUG = bool(os.getenv('SERVER_PORT', False))
+    BUILDINGS = os.getenv('BUILDINGS', 'building_config.json')
 
 
 class DevelopmentConfig(Config):

--- a/utmap-server/src/app/main/config.py
+++ b/utmap-server/src/app/main/config.py
@@ -6,6 +6,7 @@ class Config:
     SECRET_KEY = os.getenv('SECRET KEY', 'skeleton_key_sans_undertale_haha')
     MONGODB_HOST = os.getenv('MONGODB_HOST', 'localhost')
     MONGODB_PORT = int(os.getenv('MONGODB_PORT', 27017))
+    SKIP_DB_INIT = os.getenv('SKIP_DB_INIT', False)
     SERVER_HOST = os.getenv('SERVER_HOST', '127.0.0.0')
     SERVER_PORT = int(os.getenv('SERVER_PORT', 5000))
     DEBUG = bool(os.getenv('SERVER_PORT', False))
@@ -38,6 +39,7 @@ key = Config.SECRET_KEY
 
 dbHost = Config.MONGODB_HOST
 dbPort = Config.MONGODB_PORT
+skipDBInit = Config.SKIP_DB_INIT
 serverHost = Config.SERVER_HOST
 serverPort = Config.SERVER_PORT
 debugSetting = Config.DEBUG

--- a/utmap-server/src/app/static/building_config.json
+++ b/utmap-server/src/app/static/building_config.json
@@ -1,0 +1,54 @@
+[
+    {
+        "name": "Instructional Building (IB)",
+        "code": "IB" 
+    },
+    {
+        "name": "Library",
+        "code": "HM" 
+    },
+    {
+        "name": "CCT building (CCT)",
+        "code": "CC" 
+    },
+    {
+        "name": "Student Center",
+        "code": "XR" 
+    },
+    {
+        "name": "Academic Annex",
+        "code": "AX" 
+    },
+    {
+        "name": "Erindale Studio Theater",
+        "code": "DW" 
+    },
+    {
+        "name": "Deerfield Hall (DH)",
+        "code": "DH" 
+    },
+    {
+        "name": "UTM Alumni House",
+        "code": "WC" 
+    },
+    {
+        "name": "Kaneff Building (KN)",
+        "code": "KN" 
+    },
+    {
+        "name": "Davis building (DV)",
+        "code": "DV" 
+    },
+    {
+        "name": "Maanjiwe Nendamowinan (MN)",
+        "code": "MN" 
+    },
+    {
+        "name": "Green House",
+        "code": "BG" 
+    },
+    {
+        "name": "Recreation, Athletics and Wellness Center",
+        "code": "RA" 
+    }
+]

--- a/utmap-server/src/app/static/building_config.json
+++ b/utmap-server/src/app/static/building_config.json
@@ -1,6 +1,6 @@
 [
     {
-        "name": "Instructional Building (IB)",
+        "name": "Instructional Building",
         "code": "IB" 
     },
     {
@@ -8,7 +8,7 @@
         "code": "HM" 
     },
     {
-        "name": "CCT building (CCT)",
+        "name": "CCT building",
         "code": "CC" 
     },
     {
@@ -24,7 +24,7 @@
         "code": "DW" 
     },
     {
-        "name": "Deerfield Hall (DH)",
+        "name": "Deerfield Hall",
         "code": "DH" 
     },
     {
@@ -32,15 +32,15 @@
         "code": "WC" 
     },
     {
-        "name": "Kaneff Building (KN)",
+        "name": "Kaneff Building",
         "code": "KN" 
     },
     {
-        "name": "Davis building (DV)",
+        "name": "Davis building",
         "code": "DV" 
     },
     {
-        "name": "Maanjiwe Nendamowinan (MN)",
+        "name": "Maanjiwe Nendamowinan",
         "code": "MN" 
     },
     {

--- a/utmap-server/src/manage.py
+++ b/utmap-server/src/manage.py
@@ -24,10 +24,13 @@ def init_db():
     # load data from file
     SITE_ROOT = os.path.realpath(os.path.dirname(__file__))
     buildings_url = os.path.join(SITE_ROOT, 'app/static', app.config['BUILDINGS'])
-    buildings = json.load(open(buildings_url))
-    # send to db (addBuilding checks for repeats)
-    for building in buildings:
-        addBuilding(building)
+    try:
+        buildings = json.load(open(buildings_url))
+        # send to db (addBuilding checks for repeats)
+        for building in buildings:
+            addBuilding(building)
+    except(Exception):
+        pass
 
 @manager.command
 def run():

--- a/utmap-server/src/manage.py
+++ b/utmap-server/src/manage.py
@@ -4,8 +4,10 @@ import unittest
 from flask_cors import CORS
 from flask_restx import Api
 from flask_script import Manager
+from flask import json
 from app.main import createApp, serverHost, serverPort, debugSetting
 from app.main.controller import buildingController as buildCon, eventController as evCon
+from app.main.service.buildingService import addBuilding
 
 app = createApp(os.getenv('UTMAP_ENV') or 'dev')
 app.app_context().push()
@@ -17,6 +19,15 @@ api = buildCon.BuildingController().addBuildResources(api)
 api = evCon.EventController().addEvResources(api)
 
 manager = Manager(app)
+
+def init_db():
+    # load data from file
+    SITE_ROOT = os.path.realpath(os.path.dirname(__file__))
+    buildings_url = os.path.join(SITE_ROOT, 'app/static', app.config['BUILDINGS'])
+    buildings = json.load(open(buildings_url))
+    # send to db (addBuilding checks for repeats)
+    for building in buildings:
+        addBuilding(building)
 
 @manager.command
 def run():
@@ -31,4 +42,5 @@ def test():
     return 1
 
 if __name__ == '__main__':
+    init_db()
     manager.run()

--- a/utmap-server/src/manage.py
+++ b/utmap-server/src/manage.py
@@ -5,7 +5,7 @@ from flask_cors import CORS
 from flask_restx import Api
 from flask_script import Manager
 from flask import json
-from app.main import createApp, serverHost, serverPort, debugSetting
+from app.main import createApp, serverHost, serverPort, debugSetting, skipDBInit
 from app.main.controller import buildingController as buildCon, eventController as evCon
 from app.main.service.buildingService import addBuilding
 
@@ -45,5 +45,6 @@ def test():
     return 1
 
 if __name__ == '__main__':
-    init_db()
+    if not skipDBInit:
+        init_db()
     manager.run()


### PR DESCRIPTION
- Config now accepts an environment variable to specify a file of buildings anywhere in `/app/static/`
- On start, any building from the file that is not in the database will be added (Checks for the same name)
- Fix some errors in `config.py`
- Added a building config file